### PR TITLE
Add 64-bit Support

### DIFF
--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -22,6 +22,12 @@ mod ioctl {
     const VCIO_IOC_MAGIC: u8 = 100;
     const VCIO_IOC_TYPE_MODE: u8 = 0;
 
+    #[cfg(target_pointer_width = "64")]
+    ioctl_readwrite! {
+        /// mailbox_property via ioctl with VCIO_IOC_MAGIC
+        mailbox_property, VCIO_IOC_MAGIC, VCIO_IOC_TYPE_MODE, *mut nix::libc::c_char
+    }
+    #[cfg(not(target_pointer_width = "64"))]
     ioctl_readwrite! {
         /// mailbox_property via ioctl with VCIO_IOC_MAGIC
         mailbox_property, VCIO_IOC_MAGIC, VCIO_IOC_TYPE_MODE, u32
@@ -43,7 +49,11 @@ fn rpi_firmware_property_list(mb: &Mailbox, data: *mut u8, tag_size: usize) -> R
 
     // issue request to mailbox
     debug!("buf: {:?}", buf);
-    let res = unsafe { ioctl::mailbox_property(mb.as_raw_fd(), buf.as_mut_ptr()) }?;
+    #[cfg(target_pointer_width = "64")]
+    let ptr = buf.as_mut_ptr() as *mut *mut nix::libc::c_char;
+    #[cfg(not(target_pointer_width = "64"))]
+    let ptr = buf.as_mut_ptr();
+    let res = unsafe { ioctl::mailbox_property(mb.as_raw_fd(), ptr) }?;
     debug!("buf: {:?}", buf);
 
     if buf[1] != RPI_FIRMWARE_STATUS_SUCCESS as u32 {

--- a/src/kernel.rs
+++ b/src/kernel.rs
@@ -22,12 +22,12 @@ mod ioctl {
     const VCIO_IOC_MAGIC: u8 = 100;
     const VCIO_IOC_TYPE_MODE: u8 = 0;
 
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(not(target_pointer_width = "32"))]
     ioctl_readwrite! {
         /// mailbox_property via ioctl with VCIO_IOC_MAGIC
         mailbox_property, VCIO_IOC_MAGIC, VCIO_IOC_TYPE_MODE, *mut nix::libc::c_char
     }
-    #[cfg(not(target_pointer_width = "64"))]
+    #[cfg(target_pointer_width = "32")]
     ioctl_readwrite! {
         /// mailbox_property via ioctl with VCIO_IOC_MAGIC
         mailbox_property, VCIO_IOC_MAGIC, VCIO_IOC_TYPE_MODE, u32
@@ -49,9 +49,9 @@ fn rpi_firmware_property_list(mb: &Mailbox, data: *mut u8, tag_size: usize) -> R
 
     // issue request to mailbox
     debug!("buf: {:?}", buf);
-    #[cfg(target_pointer_width = "64")]
+    #[cfg(not(target_pointer_width = "32"))]
     let ptr = buf.as_mut_ptr() as *mut *mut nix::libc::c_char;
-    #[cfg(not(target_pointer_width = "64"))]
+    #[cfg(target_pointer_width = "32")]
     let ptr = buf.as_mut_ptr();
     let res = unsafe { ioctl::mailbox_property(mb.as_raw_fd(), ptr) }?;
     debug!("buf: {:?}", buf);


### PR DESCRIPTION
This update adds support for 64-bit systems. 
Currently, running rpi-mailbox on a 64-bit environment results in an `EINVAL` error. 
It appears that the type of the ioctl call has changed for 64-bit systems, so the code has been updated accordingly.

Reference: https://github.com/raspberrypi/linux/blob/rpi-6.6.y/drivers/char/broadcom/vcio.c#L25-L29

```c
#define IOCTL_MBOX_PROPERTY _IOWR(VCIO_IOC_MAGIC, 0, char *)
#ifdef CONFIG_COMPAT
#define IOCTL_MBOX_PROPERTY32 _IOWR(VCIO_IOC_MAGIC, 0, compat_uptr_t)
#endif
```

### Testing

The changes were verified using `examples/info.rs` on both aarch64 and armhf environments.

1. **Building with cross-rs:**

   ```console
   $ cross build --target=aarch64-unknown-linux-gnu --example info
   $ cross build --target=arm-unknown-linux-gnueabihf --example info
   $ file ./target/aarch64-unknown-linux-gnu/debug/examples/info
   ./target/aarch64-unknown-linux-gnu/debug/examples/info: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, BuildID[sha1]=54abeb32696ab7aab2ab978a3eebd3c8562d73d1, for GNU/Linux 3.7.0, with debug_info, not stripped
   $ file ./target/arm-unknown-linux-gnueabihf/debug/examples/info
   ./target/arm-unknown-linux-gnueabihf/debug/examples/info: ELF 32-bit LSB pie executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, for GNU/Linux 4.19.255, with debug_info, not stripped
   ```

2. **Verifying on an aarch64 environment:**

   Transferred the binary to an aarch64 system and confirmed it runs successfully. (For the armhf binary, compatibility mode was also verified.)

   ```console
   $ uname -a
   Linux raspberrypi 6.6.51+rpt-rpi-v8 #1 SMP PREEMPT Debian 1:6.6.51-1+rpt3 (2024-10-08) aarch64 GNU/Linux
   $ ./info-aarch64
   Firmware revision: Aug 30 2024 19:17:39
   Board model: 0x00000000
   Board revision: 0x00c03112
   Board MAC address: dca63270e72b
   Board serial: 0x1000000012c2479e
   ARM memory: 0x3b400000 bytes at 0x00000000
   VC memory:  0x04c00000 bytes at 0x3b400000
   Throttled: 0x0
   $ sudo dpkg --add-architecture armhf
   $ sudo apt update
   $ sudo apt install libc6:armhf
   $ ./info-armhf
   Firmware revision: Aug 30 2024 19:17:39
   Board model: 0x00000000
   Board revision: 0x00c03112
   Board MAC address: dca63270e72b
   Board serial: 0x1000000012c2479e
   ARM memory: 0x3b400000 bytes at 0x00000000
   VC memory:  0x04c00000 bytes at 0x3b400000
   Throttled: 0x0
   ```

3. **Verifying on an armhf environment:**

   Transferred the binary to an armhf system and confirmed it runs successfully.

   ```console
   $ uname -a
   Linux raspberrypi 6.1.21-v7l+ #3 SMP Tue Sep 24 08:21:55 UTC 2024 armv7l GNU/Linux
   $ ./info-armhf
   Firmware revision: Mar 17 2023 10:51:33
   Board model: 0x00000000
   Board revision: 0x00c03141
   Board MAC address: d83add0713d6
   Board serial: 0x10000000f9a9d576
   ARM memory: 0x3b400000 bytes at 0x00000000
   VC memory:  0x04c00000 bytes at 0x3b400000
   Throttled: 0x0
   ```